### PR TITLE
Check that flag match query is not null

### DIFF
--- a/src/cmd/flag.d
+++ b/src/cmd/flag.d
@@ -100,6 +100,8 @@ public class Flag {
      *   query = String to check.
      */
     public bool matches(string query) const nothrow @safe {
+        if (query == null)
+            return false;
         return
             (query.startsWith("--") && longName == query[2..$])
             || (query.startsWith("-") && shortName == query[1..2])


### PR DESCRIPTION
Without this check it causes the method to falsely match if either name is `null`.